### PR TITLE
feat: add --stdio option

### DIFF
--- a/bin/start-stdio
+++ b/bin/start-stdio
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# used for mason.nvim
+
+cd "$(dirname "$0")"/.. || exit 1
+
+./bin/start --stdio "$0"

--- a/lib/refactorex/application.ex
+++ b/lib/refactorex/application.ex
@@ -9,7 +9,7 @@ defmodule Refactorex.Application do
       [
         {
           GenLSP.Buffer,
-          [communication: {GenLSP.Communication.TCP, [port: port()]}]
+          [communication: communication_config()]
         },
         {Refactorex.Logger, []},
         {Refactorex.NameCache, []},
@@ -20,10 +20,24 @@ defmodule Refactorex.Application do
     )
   end
 
-  defp port do
+  defp parse_opts do
     System.argv()
-    |> OptionParser.parse(strict: [port: :integer])
+    |> OptionParser.parse(strict: [port: :integer, stdio: :boolean])
     |> elem(0)
+  end
+
+  defp port do
+    parse_opts()
     |> Keyword.get(:port, @default_port)
+  end
+
+  defp communication_config do
+    opts = parse_opts()
+
+    if Keyword.get(opts, :stdio, false) do
+      {GenLSP.Communication.Stdio, []}
+    else
+      {GenLSP.Communication.TCP, [port: port()]}
+    end
   end
 end


### PR DESCRIPTION
I've created a neovim plugin for RefactorEx: https://github.com/synic/refactorex. This works for now, but it's not ideal. Ideally, it would be added to the mason registry at https://github.com/mason-org/mason-registry. 

Mason is just a package manager for LSP servers (and DAP servers, etc), which allows a neovim user to easily search for and install lsp servers. 

The trouble is, mason doesn't provide for configuring an lsp server with a tcp transport. As far as I can tell (happy to be proven wrong here), not one server in their registry uses any transport other than stdio. It seems most language servers, even the elixir based ones, all use stdio now (see elixir-ls or nextls).

Other benefits of using stdio vs tcp are that you don't have to hunt down a port or worry about any of that. I'm pretty sure VSCode can just use stdio too, and it might make the setup and usage less complicated and error prone.

I've tried this out, running `./bin/start --stdio` and then connecting to it via neovim just works. If/when this gets merged, I can then submit a PR to the mason registry, which will give all neovim users super easy access to RefactorEx