### PR TITLE
fix: remove unnecessary "bin/start-stdio" script

### DIFF
--- a/bin/start-stdio
+++ b/bin/start-stdio
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-# used for mason.nvim
-
-cd "$(dirname "$0")"/.. || exit 1
-
-./bin/start --stdio "$0"


### PR DESCRIPTION
I think I figured out how it's supposed to work without adding additional scripts or worrying about passed arguments.

The mason-registry submission is here: https://github.com/mason-org/mason-registry/pull/8368

Once refactorex is installed with mason, it can be configured using the following code:

```lua
require("lspconfig.configs").refactorex = {
  default_config = {
    cmd = { vim.fn.stdpath("data") .. "/mason/bin/refactorex", "--stdio" },
    filetypes = { "elixir" },
    root_dir = function(fname)
      return require("lspconfig").util.root_pattern("mix.exs")(fname)
    end,
    settings = {},
    capabilities = {
      textDocumentSync = {
        openClose = true,
        change = 1,
        save = { includeText = true },
      },
      codeActionProvider = {
        resolveProvider = true,
      },
      renameProvider = {
        prepareProvider = true,
      },
    },
  },
}

require("lspconfig").refactorex.setup({})
```

As you can see, the `cmd` has the `--stdio` argument. Mason's job is mainly just to install the language server, not to actually say what will be done with it.

For maximum ease, once it is accepted in Mason, we will need to also submit it to https://github.com/williamboman/mason-lspconfig.nvim, similar to how nextls has done it here:
https://github.com/williamboman/mason-lspconfig.nvim/blob/main/lua/mason-lspconfig/server_configurations/nextls/init.lua

```lua
return function()
  return {
    cmd = { "nextls", "--stdio" },
  }
end
```

So, mason is just to install the language server, mason-lspconfig is what provides the easy-to-use lsp configuration. Until it's accepted in `mason-lspconfig`, your friends can use the snippet above to get it working (once it's accepted to mason itself).

Until it's accepted in mason, they can just use this plugin: https://github.com/synic/refactorex.nvim - it just downloads the refactorex source code to a local directory and runs it from there. Seems to work just fine.

Sorry about the runaround with `bin/start-stdio` - learning all of this as I go ;-)